### PR TITLE
Drop explicit python2.7 dependency from tests

### DIFF
--- a/pylxca/test/pylxca_unittest
+++ b/pylxca/test/pylxca_unittest
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/python2.7
+#!/usr/bin/env python
 import time
 import os
 import sys

--- a/pylxca/test/test_pylxca
+++ b/pylxca/test/test_pylxca
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/python2.7
+#!/usr/bin/env python
 '''
 @since: 31 March 2016
 @author: Prashant Bhosale <pbhosale@lenovo.com>


### PR DESCRIPTION
These two test files explicitly call for python2.7 rather than using the standard `#!/usr/bin/env python` shebang.

Fixes https://github.com/lenovo/pylxca/issues/17